### PR TITLE
remove ghost form by setting action dynamically

### DIFF
--- a/app/controllers/v2/meetings_controller.rb
+++ b/app/controllers/v2/meetings_controller.rb
@@ -8,8 +8,8 @@ class V2::MeetingsController < ApplicationController
   end
 
   def refresh
-    @meeting = Meeting.new(meeting_params(scope: :ghost_meeting))
-    render :new
+    @meeting = Meeting.new(meeting_params)
+    render :new, status: :see_other
   end
 
   def create
@@ -26,7 +26,7 @@ class V2::MeetingsController < ApplicationController
 
   private
 
-  def meeting_params(scope: :meeting)
-    params.require(scope).permit(:title, :category, :meeting_room, :meeting_url)
+  def meeting_params
+    params.require(:meeting).permit(:title, :category, :meeting_room, :meeting_url)
   end
 end

--- a/app/javascript/controllers/ghost_form_controller.js
+++ b/app/javascript/controllers/ghost_form_controller.js
@@ -6,18 +6,9 @@ export default class extends Controller {
 
   connect() {
   }
-  submit(event) {
-    const formData = new FormData(this.originalFormTarget)
-    formData.delete("_method")
-    formData.delete("authenticity_token")
 
-    for (const [key, value] of formData.entries()) {
-      const ghost_key = "ghost_" + key
-      const input = this.ghostFormTarget.querySelector(`input[name="${ghost_key}"]`)
-      if (input) {
-        input.value = value;
-      }
-    }
-    this.ghostFormTarget.requestSubmit()
+  requestResetForm(event) {
+    this.originalFormTarget.action = this.originalFormTarget.dataset["urlForRequestResetForm"]
+    this.originalFormTarget.requestSubmit()
   }
 }

--- a/app/views/v2/meetings/_form.html.erb
+++ b/app/views/v2/meetings/_form.html.erb
@@ -1,5 +1,15 @@
 <turbo-frame id="meeting-form" data-controller="ghost-form">
-  <%= form_with model: @meeting, url: v2_meetings_path, data: { "turbo-frame" => "_top", "ghost-form-target" => "originalForm" } do |f| %>
+  <%=
+    form_with(
+      model: @meeting,
+      url: v2_meetings_path,
+      data: {
+        "turbo-frame" => "_top",
+        "ghost-form-target" => "originalForm",
+        "url-for-request-reset-form" => refresh_new_v2_meeting_path,
+      }
+    ) do |f|
+  %>
     <div style="margin-bottom: 1rem;">
       <div><%= f.label :title %></div>
       <div><%= f.text_field :title %></div>
@@ -7,13 +17,13 @@
     </div>
     <div style="margin-bottom: 1rem;">
       <div>Category</div>
-      <%= f.radio_button :category, "real", data: { action: "ghost-form#submit" } %>
+      <%= f.radio_button :category, "real", data: { action: "ghost-form#requestResetForm" } %>
       <%= f.label :category, "Real", value: "real" %>
 
-      <%= f.radio_button :category, "online", data: { action: "ghost-form#submit" } %>
+      <%= f.radio_button :category, "online", data: { action: "ghost-form#requestResetForm" } %>
       <%= f.label :category, "Online", value: "online" %>
 
-      <%= f.radio_button :category, "hybrid", data: { action: "ghost-form#submit" } %>
+      <%= f.radio_button :category, "hybrid", data: { action: "ghost-form#requestResetForm" } %>
       <%= f.label :category, "Hybrid", value: "hybrid" %>
     </div>
     <% if %w[real hybrid].include?(@meeting.category) %>
@@ -31,11 +41,5 @@
     <div>
       <%= f.submit %>
     </div>
-  <% end %>
-  <%= form_with scope: "ghost_meeting", model: @meeting, url: refresh_new_v2_meeting_path, method: :post, data: { "ghost-form-target" => "ghostForm" } do |f| %>
-    <%= f.hidden_field :title %>
-    <%= f.hidden_field :category %>
-    <%= f.hidden_field :meeting_room %>
-    <%= f.hidden_field :meeting_url %>
   <% end %>
 </turbo-frame>


### PR DESCRIPTION
オリジナル `<form>` の `action` の値を動的に変更することで、 "ghost" `<form>` を不要にします。